### PR TITLE
Default condition should be last one

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "module": "./dist/index.module.js",
   "exports": {
     ".": {
-      "default": "./dist/index.module.js",
-      "require": "./dist/index.cjs"
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.module.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
> "default" - the generic fallback that always matches. Can be a CommonJS or ES module file. **This condition should always come last.**

From: https://nodejs.org/api/packages.html#conditional-exports
