### PR TITLE
Cleanup package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,19 @@
   "license": "MIT",
   "files": ["dist", "src"],
   "source": "src/index.ts",
-  "main": "./dist/index.cjs",
   "module": "./dist/index.module.js",
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.cjs",
-      "default": "./dist/index.module.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.module.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
   "scripts": {


### PR DESCRIPTION
Copying the format from [`lago-javascript-client`](https://www.npmjs.com/package/lago-javascript-client?activeTab=code) which was [generated by dnt](https://arjunyel.com/blog/how-to-create-a-npm-package-in-2023/)